### PR TITLE
Update expiration validation and 3DS dialog style

### DIFF
--- a/android/src/main/kotlin/com/shushper/cloudpayments/sdk/cp_card/CPCard.java
+++ b/android/src/main/kotlin/com/shushper/cloudpayments/sdk/cp_card/CPCard.java
@@ -141,7 +141,7 @@ public class CPCard {
      * Валидация даты
      * @return
      */
-    public static boolean isValidExpDate(String expDate) {
+     public static boolean isValidExpDate(String expDate) {
         if (expDate.length() != 4) {
             return false;
         }
@@ -155,16 +155,17 @@ public class CPCard {
             calendar.set(Calendar.DAY_OF_MONTH, calendar.getActualMaximum(Calendar.DAY_OF_MONTH));
             date = calendar.getTime();
 
-            Date currentDate = new Date();
-            if (currentDate.before(date)) {
+            Calendar currentCalendar = Calendar.getInstance();
+            int currentYear = currentCalendar.get(Calendar.YEAR) % 100; // Получаем последние две цифры текущего года
+            int cardYear = calendar.get(Calendar.YEAR) % 100; // Получаем последние две цифры года окончания срока действия карты
+
+            if (cardYear >= 21) { // Если срок годности карты истекает после 2021 года или позже
                 return true;
-            } else {
-                return false;
             }
         } catch (ParseException e) {
             e.printStackTrace();
-            return false;
         }
+        return false;
     }
 
     /**

--- a/android/src/main/kotlin/com/shushper/cloudpayments/sdk/three_ds/ThreeDsDialogFragment.java
+++ b/android/src/main/kotlin/com/shushper/cloudpayments/sdk/three_ds/ThreeDsDialogFragment.java
@@ -68,6 +68,7 @@ public class ThreeDsDialogFragment extends DialogFragment {
         md = getArguments().getString(MD);
         paReq = getArguments().getString(PA_REQ);
         termUrl = getArguments().getString(TERM_URL);
+        setStyle(DialogFragment.STYLE_NO_TITLE, R.style.FullScreenDialog);
     }
 
     @Override

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources> 
-<style name="FullScreenDialog" parent="Theme.AppCompat.Light.Dialog">
+<style name="FullScreenDialog">
         <item name="android:backgroundDimEnabled">false</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:padding">0dp</item>
@@ -8,4 +8,4 @@
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowCloseOnTouchOutside">false</item>
     </style>
-</resources> 
+</resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources> 
+<style name="FullScreenDialog" parent="Theme.AppCompat.Light.Dialog">
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:padding">0dp</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowCloseOnTouchOutside">false</item>
+    </style>
+</resources> 

--- a/ios/Classes/sdk/Card/Card.m
+++ b/ios/Classes/sdk/Card/Card.m
@@ -170,36 +170,16 @@
     [dateFormatter setDateFormat:@"MM/yy"];
     NSDate *date = [dateFormatter dateFromString:expDateString];
     
-    // get last day of the current month
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    [calendar setTimeZone:[NSTimeZone systemTimeZone]];
-
-    NSRange dayRange = [ calendar rangeOfUnit:NSCalendarUnitDay
-                                       inUnit:NSCalendarUnitMonth
-                                      forDate:date];
-
-    NSInteger numberOfDaysInCurrentMonth = dayRange.length;
-
-    NSDateComponents *comp = [calendar components:
-                              NSCalendarUnitYear |
-                              NSCalendarUnitMonth |
-                              NSCalendarUnitDay fromDate:date];
-
-    comp.day = numberOfDaysInCurrentMonth;
-    comp.hour = 24;
-    comp.minute = 0;
-    comp.second = 0;
-
-    date = [calendar dateFromComponents:comp];
+    NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitYear fromDate:date];
+    NSInteger year = [components year];
     
-    NSDate *now = [NSDate new];
-    
-    if([date compare: now] == NSOrderedDescending){
+    if (year >= 21) { // Если срок годности карты истекает после 2021 года или позже
         return true;
     }
     
     return false;
 }
+
 
 +(CardType) cardTypeFromCardNumber:(NSString *)cardNumberString {
     NSString *cleanCardNumber = [Card cleanCreditCardNo:cardNumberString];


### PR DESCRIPTION
* Simplified expiration date validation to check year >= 2021 (Android/iOS)
* Added full-screen styling for 3DS verification dialog
* Removed background dimming and title from 3DS dialog
* Updated date parsing logic to use Calendar component in Android validation